### PR TITLE
Added <dc:creator> tag for actual author of tweet.

### DIFF
--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -145,6 +145,7 @@ for (@items) {
   print<<ENDITEM
     <item>
       <title>$_->{title}</title>
+      <dc:creator><![CDATA[$_->{fullname} ($_->{username})]]></dc:creator>
       <description>$_->{description}</description>
       <pubDate>$_->{pubDate}</pubDate>
       <guid>$_->{guid}</guid>

--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -131,7 +131,7 @@ Content-type: application/rss+xml
 Cache-control: max-age=$max_age
 
 <?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss" xmlns:twitter="http://api.twitter.com" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss" xmlns:twitter="http://api.twitter.com" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
   <channel>
     <title>Twitter Search / $user </title>
     <link>http://twitter.com/$user</link>


### PR DESCRIPTION
 * `<dc:creator>` contains the fullname and username of the original
author of the tweet. Makes it easier to read tweets combined from
multiple RSS feeds as well as clarifying retweets.