### PR TITLE
Use correct URL for with_replies.

### DIFF
--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -57,7 +57,7 @@ while (my $q = CGI::Fast->new) {
 	my $url = "$BASEURL/$user";
 	$url .= "/with_replies" if $replies;
 
-	my $response = $browser->get("$BASEURL/$user");
+	my $response = $browser->get($url);
 	unless ($response->is_success) {
 		err('Can&#8217;t screenscrape Twitter',404);
 		next;


### PR DESCRIPTION
The existing code correctly generates `$url` using `$replies` and then never reads it and uses `"$BASEURL/$user"` as the URL instead.