### PR TITLE
Get username casing for title of feed from Twitter page.

### DIFF
--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -72,6 +72,12 @@ while (my $q = CGI::Fast->new) {
 
   my $tree= HTML::TreeBuilder::XPath->new;
   $tree->parse($content);
+
+  # Get capitalization from Twitter page
+  my $normalizedName = $tree->findvalue('//a' . class_contains("ProfileHeaderCard-screennameLink") . "/\@href");
+  $normalizedName =~ s{^/}{};
+  $user = $normalizedName;
+
   my $tweets = $tree->findnodes( '//li' . class_contains('js-stream-item')); # new version 2015-06-02
 
   if ($tweets) {


### PR DESCRIPTION
This only affects the name of the feed ("Twitter Search / WhoEver"), since the post creator names are already loaded from the page.