### PR TITLE
Allow specifying src paramater for searches

### DIFF
--- a/fcgi/twitter_search_to_rss.pl
+++ b/fcgi/twitter_search_to_rss.pl
@@ -23,6 +23,7 @@ while (my $q = CGI::Fast->new) {
   next if $bad_param;
 
   my $term = $q->param('term') || '#triffidinvasion';
+  my $src = $q->param('src') || 'typd';
 
   $term = lc $term;
   if($term =~ '^@') {
@@ -35,6 +36,6 @@ while (my $q = CGI::Fast->new) {
   my @items       = items_from_feed($content);
   my $feed_url    = "$OWN_BASEURL/?term=$term";
   my $feed_title  = "Twitter search feed for: $term.";
-  my $twitter_url = "$TWITTER_BASEURL/search?f=tweets&amp;src=typd&amp;q=$term";
+  my $twitter_url = "$TWITTER_BASEURL/search?f=tweets&amp;src=$src&amp;q=$term";
   display_feed($feed_url, $feed_title, $twitter_url, @items);
 }


### PR DESCRIPTION
I'd like to have a feed of search results that contain a word that is not in a dictionary.  This word's spelling is very close to a dictionary word, and Twitter "helpfully" corrects it on my behalf.  In the web UI, there's an option to override this helpfulness and Twitter will only search for the entered spelling instead of the corrected spelling.  This is done by adding or changing the `src` parameter to `spxr`.  This PR simply allows specifying the `src` parameter in the query string and passing it along to Twitter.  It will default to the existing `typd` value if no parameter was specified in the URL.