### PR TITLE
TwitRSS.me in a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+Dockerfile
+INSTALL.*
+LICENSE
+README.md
+#cpanfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:xenial
+
+# Copy all the files into /var/www/twitrssme
+# The .gitignore file filters out the ones we don't want
+WORKDIR /var/www/twitrssme
+COPY . /var/www/twitrssme/
+
+# 1. Install the ubuntu packages
+# 2. Enable the apache modules
+# 3. Install the required CPAN modules
+# 4. Clean up the ubuntu packages we don't need
+# 5. Set up the apache conf and logging
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apache2 \
+        build-essential \
+        cpanminus \
+        libapache2-mod-fastcgi \
+        libcurl3-dev \
+        libxml2-dev \
+        zlib1g-dev \
+ && a2enmod expires \
+ && a2enmod fastcgi \
+ && cpanm --installdeps -q . \
+ && DEBIAN_FRONTEND=noninteractive apt-get remove --auto-remove -y \
+        build-essential \
+ && DEBIAN_FRONTEND=noninteractive apt-get clean -y \
+ && rm -rf /root/.cpanm \
+ && mv /var/www/twitrssme/apache.conf \
+       /etc/apache2/sites-enabled/000-default.conf \
+ && ln -sf /dev/stdout /var/log/apache2/twitrssme.access.log \
+ && ln -sf /dev/stdout /var/log/apache2/access.log \
+ && ln -sf /dev/stderr /var/log/apache2/twitrssme.error.log \
+ && ln -sf /dev/stderr /var/log/apache2/error.log
+
+CMD [ "apachectl", "-D", "FOREGROUND" ]
+
+EXPOSE 80

--- a/INSTALL.docker.md
+++ b/INSTALL.docker.md
@@ -1,0 +1,39 @@
+# Running TwitRSS.me with Docker
+
+A Dockerfile and docker-compose.yml have been created to run TwitRSS.me under Docker. All you need is a working Docker installation, and optionally Docker Compose.
+
+## Step 0: Install docker
+
+Refer to https://docs.docker.com/install/ for installing Docker.
+
+## Step 1: Build an image
+
+We'll use `twitrssme` as the image name, but you can use any legal image name here.
+
+  `docker build -t twitrssme .`
+
+The first time through this will take a little while.
+
+## Step 2: Run the container
+
+This command will start the container in the foreground, listening on port 3000.
+
+  `docker run --rm --port 3000:80 twitrssme`
+
+To run it in the background, add the `--detach` flag.
+
+  `docker run --rm --detach --port 3000:80 twitrssme`
+
+That's all you need. Your TwitRSS.me server will be available on http://localhost:3000/ .
+
+# Running TwitRSS.me with Docker Compose
+
+A `docker-compose.yml` is provided which mounts the local directory to `/var/www/twitrssme` in the container. This is handy for development as any local changes are available immediately in the running container, with no image rebuild neessary.
+
+To start TwitRSS.me in Docker Compose, use:
+
+  `docker-compose up`
+
+Docker Compose will build the image if necessary, and then run the container.
+
+As before, your TwitRSS.me server will be available on http://localhost:3000/ .

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,10 +37,10 @@ Step 3: Get CPAN modules
 
 Perl is probably installed already, but install it if not.
 
-I use cpanminus to manage Perl dependencies but you may want to use apt, though LWP::Protocol::Net::Curl is not in the Debian repositories. You will also need libcurl3-dev.
+I use cpanminus to manage Perl dependencies but you may want to use apt, though LWP::Protocol::Net::Curl is not in the Debian repositories. You will also need libcurl3-dev. The required Perl dependencies are listed in cpanfile.
 
      sudo aptitude install cpanm libcurl3-dev
-     sudo cpanm CGI::Fast Data::Dumper Encode Net::Curl HTML::Entities HTML::TreeBuilder::LibXML HTML::TreeBuilder::XPath LWP::ConnCache LWP::Protocol::Net::Curl LWP::UserAgent POSIX Readonly
+     sudo cpanm --installdeps .
 
 Once all is installed you should be able to go in to /var/www/twitrssme/fcgi and run the Perl script thus.
 

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,25 @@
+<VirtualHost *:80>
+  DocumentRoot /var/www/twitrssme/
+
+  <Directory /var/www/twitrssme/>
+     Options +ExecCGI +SymLinksIfOwnerMatch -MultiViews +Includes
+     AllowOverride None
+     Order allow,deny
+     allow from all
+  </Directory>
+
+  FastCgiServer /var/www/twitrssme/fcgi/twitter_user_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20
+  ScriptAlias /twitter_user_to_rss/ /var/www/twitrssme/fcgi/twitter_user_to_rss.pl
+
+  FastCgiServer /var/www/twitrssme/fcgi/twitter_search_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20
+  ScriptAlias /twitter_search_to_rss/ /var/www/twitrssme/fcgi/twitter_search_to_rss.pl
+
+  <Directory /var/www/twitrssme/fcgi>
+        SetHandler fastcgi-script
+        ExpiresActive Off
+  </Directory>
+
+  ErrorLog ${APACHE_LOG_DIR}/twitrssme.error.log
+  LogLevel warn
+  CustomLog ${APACHE_LOG_DIR}/twitrssme.access.log varnish_vhost_combined
+</VirtualHost>

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,12 @@
+requires 'CGI::Fast';
+requires 'Data::Dumper';
+requires 'Encode';
+requires 'Net::Curl';
+requires 'HTML::Entities';
+requires 'HTML::TreeBuilder::LibXML';
+requires 'HTML::TreeBuilder::XPath';
+requires 'LWP::ConnCache';
+requires 'LWP::Protocol::Net::Curl';
+requires 'LWP::UserAgent';
+requires 'POSIX';
+requires 'Readonly';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2.3"
+
+services:
+  twitrssme:
+    build: .
+    ports:
+      - 3000:80
+    volumes:
+      - .:/var/www/twitrssme


### PR DESCRIPTION
First let me say thanks very much for creating TwitRSS.me - I've been using it in conjunction with [rss2imap](https://github.com/rcarmo/rss2imap) for quite a while now.

I saw you were having rate limiting issues, and suggesting people run their own instances.

Here's a Dockerfile and a few other bits and pieces which will hopefully make that easier for people to do.

I've created an [automated build](https://hub.docker.com/r/sdthirlwall/twitrssme/) on docker hub as a sample. You can try it out with:

  `docker run --rm -p 3000:80 sdthirlwall/twitrssme`

That will pull the image and run up a local TwitRSS.me server on http://localhost:3000/

There's a bit more information in INSTALL.docker.md