### PR TITLE
added code and configuration for setting own base urls and traefik settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It does this by connecting to Twitter on the web and screenscraping the data, ra
 Installation
 ------------
 
-You can install TwitRSS.me by following the instructions in the [INSTALL.md](blob/master/INSTALL.md) file.
+You can install TwitRSS.me by following the instructions in the [INSTALL.md](INSTALL.md) file.
 
 The main reason for doing so is that the caching limits (one query every 45 minutes) is proving restrictive.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@ It does this by connecting to Twitter on the web and screenscraping the data, ra
 Installation
 ------------
 
-You can install TwitRSS.me by following the instructions in the [INSTALL.md](https://github.com/ciderpunx/twitrssme/blob/master/INSTALL.md) file.
+You can install TwitRSS.me by following the instructions in the [INSTALL.md](blob/master/INSTALL.md) file.
 
 The main reason for doing so is that the caching limits (one query every 45 minutes) is proving restrictive.
+
+The most easiest way to use TwitRSS.me is just to clone this git-repository, build and run the image in docker:
+
+      git clone <this repo>
+      cp example.env .env
+      vi .env
+      docker-compose up -d --build
 
 History
 -------

--- a/apache.conf
+++ b/apache.conf
@@ -7,11 +7,11 @@
      Order allow,deny
      allow from all
   </Directory>
-
-  FastCgiServer /var/www/twitrssme/fcgi/twitter_user_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20
+  
+  FastCgiServer /var/www/twitrssme/fcgi/twitter_user_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20 -initial-env OWN_BASEURL_USER
   ScriptAlias /twitter_user_to_rss/ /var/www/twitrssme/fcgi/twitter_user_to_rss.pl
 
-  FastCgiServer /var/www/twitrssme/fcgi/twitter_search_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20
+  FastCgiServer /var/www/twitrssme/fcgi/twitter_search_to_rss.pl -processes 5 -idle-timeout 5 -appConnTimeout 3 -priority 18 -listen-queue-depth 20 -initial-env OWN_BASEURL_SEARCH 
   ScriptAlias /twitter_search_to_rss/ /var/www/twitrssme/fcgi/twitter_search_to_rss.pl
 
   <Directory /var/www/twitrssme/fcgi>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,19 @@
-version: "2.3"
+version: "2"
 
 services:
   twitrssme:
+    container_name: twitrssme
     build: .
     ports:
       - 3000:80
     volumes:
       - .:/var/www/twitrssme
+    environment:
+      # you may set your own server url, edit environment variables in .env-file, see example.env
+      # if not set, hardcoded standards will be used:
+      - OWN_BASEURL_SEARCH
+      - OWN_BASEURL_USER
+    labels:
+      - "traefik.frontend.rule=Host:${TRAEFIK_HOST}"
+      - "traefik.port=${TRAEFIK_PORT}"
+

--- a/example.env
+++ b/example.env
@@ -1,0 +1,13 @@
+# Example configuration file
+# Please rename to .env before using docker-compose
+
+# twitrssme environment
+OWN_BASEURL_SEARCH=http://twitrss.me/twitter_search_to_rss
+OWN_BASEURL_USER=http://twitrss.me/twitter_user_to_rss
+
+# traefik labels
+# useful, if you are using traefik as frontend to twitrssme
+TRAEFIK_HOST=twitrss.me
+TRAEFIK_PORT=80
+
+

--- a/fcgi/twitter_search_to_rss.pl
+++ b/fcgi/twitter_search_to_rss.pl
@@ -8,7 +8,11 @@ use CGI::Fast;
 use Readonly;
 use TwitRSS;
 
-Readonly my $OWN_BASEURL => 'http://twitrss.me/twitter_search_to_rss';
+my $URL = $ENV{'OWN_BASEURL_SEARCH'};
+if ( not defined $URL ) {
+  $URL = 'http://twitrss.me/twitter_search_to_rss';
+}
+Readonly my $OWN_BASEURL => $URL;
 
 while (my $q = CGI::Fast->new) {
   my @ps = $q->param; 

--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -21,7 +21,13 @@ binmode STDIN, 'utf8';
 HTML::TreeBuilder::LibXML->replace_original();
 
 Readonly my $BASEURL    => 'https://twitter.com';
-Readonly my $OWNBASEURL => 'http://twitrss.me/twitter_user_to_rss';
+
+my $URL = $ENV{'OWN_BASEURL_USER'};
+if ( not defined $URL ) {
+  $URL = 'http://twitrss.me/twitter_user_to_rss';
+}
+Readonly my $OWNBASEURL => $URL;
+
 my $browser = LWP::UserAgent->new;
 $browser->agent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36');
 $browser->conn_cache(LWP::ConnCache->new(5));


### PR DESCRIPTION
When merging this pull-request users can configure the Base-URLs for twitrss.me in environment variables in docker-compose.yml : 

      environment:
        - OWN_BASEURL_SEARCH=http://twitrss.me/twitter_search_to_rss
        - OWN_BASEURL_USER=http://twitrss.me/twitter_user_to_rss

when the environment is not set, then the hardcoded settings are used the same way like before.

I added also a docker .env example.
The configuration has also example settings for ssl proxying with [traefik](https://traefik.io).