### PR TITLE
Don't show tweets duplicated, set "Tweet" as title

### DIFF
--- a/fcgi/TwitRSS.pm
+++ b/fcgi/TwitRSS.pm
@@ -124,9 +124,7 @@ sub items_from_feed {
       $username =~ s{<[^>]+>}{}g;
       $username =~ s{^\s+}{};
       $username =~ s{\s+$}{};
-      my $title = enctxt($bd->as_text);
-      $title=~s{&nbsp;}{}gi;
-      $title=~s{http}{ http}; # links in title lose space
+      my $title = 'Tweet';
       my $uri = $TWITTER_BASEURL . $tweet->findvalue('@data-permalink-path');  
       my $timestamp = $tweet->findnodes('./div/div'
         . class_contains("stream-item-header")

--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -130,9 +130,7 @@ while (my $q = CGI::Fast->new) {
       $username =~ s{<[^>]+>}{}g;
       $username =~ s{^\s+}{};
       $username =~ s{\s+$}{};
-      my $title = enctxt($bd->as_text);
-      $title=~s{&nbsp;}{}gi;
-      $title=~s{http}{ http}; # links in title lose space
+      my $title = 'Tweet';
       my $uri = $BASEURL . $tweet->findvalue('@data-permalink-path');  
       my $timestamp = $tweet->findnodes('./div/div'
                       . class_contains("stream-item-header")


### PR DESCRIPTION
RSS items have a title and a description, but tweets only have a single piece of text content. Currently TwitRSS.me sets the content of the tweet both as title and description, so RSS readers show each tweet text twice. This duplication takes up screen space and adds no value imho. I have replaced the title simply with the text "Tweet" - so I have something to click to load the tweet in Twitter.

Another, perhaps better solution could be to show the first 10-15 characters of the tweet in the title.

Thank you for TwitRSS.me! It is a great help.