### PR TITLE
Fix mobile scraping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
         zlib1g-dev \
  && a2enmod expires \
  && a2enmod fastcgi \
- && cpanm --installdeps -q . \
+ && cpanm --installdeps -q -f . \
  && DEBIAN_FRONTEND=noninteractive apt-get remove --auto-remove -y \
         build-essential \
  && DEBIAN_FRONTEND=noninteractive apt-get clean -y \

--- a/cpanfile
+++ b/cpanfile
@@ -10,3 +10,5 @@ requires 'LWP::Protocol::Net::Curl';
 requires 'LWP::UserAgent';
 requires 'POSIX';
 requires 'Readonly';
+requires 'DateTime';
+requires 'DateTime::Format::Strptime';

--- a/fcgi/mobile_twitter_to_rss.pl
+++ b/fcgi/mobile_twitter_to_rss.pl
@@ -82,7 +82,6 @@ while (my $q = CGI::Fast->new) {
 
   # Get capitalization from Twitter page
   my $normalizedName = $tree->findvalue('//div' . class_contains("fullname"));
-  say $normalizedName;
 
   my $tweets = $tree->findnodes( '//table' . class_contains('tweet'));
 
@@ -122,7 +121,7 @@ while (my $q = CGI::Fast->new) {
       my $title = enctxt($bd->as_text);
       $title=~s{&nbsp;}{}gi;
       $title=~s{http}{ http}; # links in title lose space
-      my $uri = $BASEURL . $tweet->findvalue('@data-permalink-path');
+      my $uri = $BASEURL . $tweet->findvalue('@href');
       # Limitation: actual timestamps not present in the feed, we have to work out the best we can from the approximate versions given.
       my $timestamp = $header->findvalue('./td'
                       . class_contains("timestamp")


### PR DESCRIPTION
* The tweet no longer has a data-permalink-path, but it does have an href attribute.
* Remove rogue say that breaks script
* Add mobile scraper dependencies to cpanfile
* Force cpanm to install even if tests fail in Dockerfile