### PR TITLE
Enable cookies because Twitter now requires them.

### DIFF
--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -24,6 +24,11 @@ Readonly my $BASEURL    => 'https://twitter.com';
 Readonly my $OWNBASEURL => 'http://twitrss.me/twitter_user_to_rss';
 my $browser = LWP::UserAgent->new;
 $browser->agent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36');
+
+# From http://lwp.interglacial.com/ch11_01.htm#perllwp-CHP-11-SECT-1
+# Enables cookies
+$browser->cookie_jar( {} );
+
 $browser->conn_cache(LWP::ConnCache->new(5));
 $browser->timeout(2);
 

--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -66,6 +66,8 @@ while (my $q = CGI::Fast->new) {
   my $url = "$BASEURL/$user";
   $url .= "/with_replies" if $replies;
 
+  # Clear cookies before every request.
+  $browser->cookie_jar( {} );
   my $response = $browser->get($url);
   unless ($response->is_success) {
     err('Can&#8217;t screenscrape Twitter',404);


### PR DESCRIPTION
I believe this fixes #75. At least, Twitter also broke for me a few days ago and this change fixed it.

I discovered the issue by changing
```perl
    err('Can&#8217;t screenscrape Twitter',404);
```
to
```perl
    err(Dumper($response) . 'Can&#8217;t screenscrape Twitter',404);
```
and seeing that the issue was a redirect loop to the same URL. [This StackOverflow answer](https://webmasters.stackexchange.com/a/74509) mentioned that redirect loops are sometimes used to set and check cookies and [the `LWP::UserAgent` docs on cookies](http://lwp.interglacial.com/ch11_01.htm#perllwp-CHP-11-SECT-1) gave the code for the minimal way to enable cookies.