### PR TITLE
Restore functionality after recent Twitter update.

### DIFF
--- a/fcgi/twitter_user_to_rss.pl
+++ b/fcgi/twitter_user_to_rss.pl
@@ -74,7 +74,8 @@ while (my $q = CGI::Fast->new) {
 
   # Clear cookies before every request.
   $browser->cookie_jar( {} );
-  my $response = $browser->get($url);
+  my $response = $browser->get($url,
+    "X-Requested-With" => "XMLHttpRequest");
   unless ($response->is_success) {
     err('Can&#8217;t screenscrape Twitter',404);
     next;


### PR DESCRIPTION
Fixes #92 by adding the X-Requested-With: XMLHttpRequest header to the request. Thanks to @votemp pointing to the fix in twintproject/twint@1ad346b in that issue thread.